### PR TITLE
[Merge] 잡행 요청 페이지 작성

### DIFF
--- a/components/Item/index.tsx
+++ b/components/Item/index.tsx
@@ -1,0 +1,31 @@
+import styled from '@emotion/styled';
+import React from 'react';
+import { ItemTypes } from 'store';
+
+type Props = {
+    item: ItemTypes;
+};
+
+const Item = (props: Props) => {
+    const { item } = props;
+    return (
+        <ItemWrapper>
+            <div>{item.title}</div>
+            <div>{item.location}</div>
+            <div>{item.date}</div>
+            <div>{item.contents}</div>
+            <div>{item.reward}</div>
+        </ItemWrapper>
+    );
+};
+
+const ItemWrapper = styled.div`
+    position: relative;
+    max-width: 90%;
+    height: 90%;
+    margin: 7.5% auto;
+    overflow: auto;
+    background-color: aliceblue;
+`;
+
+export default Item;

--- a/components/ItemList/ItemList.tsx
+++ b/components/ItemList/ItemList.tsx
@@ -3,11 +3,13 @@ import { dbService } from 'fbase';
 import {
     collection,
     DocumentData,
+    getDocs,
     onSnapshot,
     orderBy,
     query,
     QueryDocumentSnapshot,
 } from 'firebase/firestore';
+import Link from 'next/link';
 import React, { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { useSelector } from 'react-redux';
@@ -23,6 +25,10 @@ const ItemList = (props: Props) => {
         const collectionRef = collection(dbService, 'items');
         const q = query(collectionRef, orderBy('date', 'desc'));
         const unsubscribe = onSnapshot(q, (querySnapshot) => {
+            // console.log('q: ', q);
+            // console.log('querySnapshot: ', querySnapshot);
+            // console.log('docs: ', ...querySnapshot.docs);
+            // console.log('doc.data(): ', querySnapshot.docs[0].data());
             const itemsArray = querySnapshot.docs.map(
                 (doc: QueryDocumentSnapshot<DocumentData>) => ({
                     ...doc.data(),
@@ -30,22 +36,23 @@ const ItemList = (props: Props) => {
                     date: doc.data().date?.toDate().getTime(),
                 }),
             );
-            dispatch(itemListAction.itemList(itemsArray));
+            dispatch(itemListAction.load(itemsArray));
         });
         return unsubscribe;
     }, []);
-    console.log(itemList);
 
     return (
         <>
             {itemList.map((item) => (
-                <PostBox key={item.id}>
-                    <div>{item.ongoing ? '진행 중' : null}</div>
-                    <div>{item.title}</div>
-                    <div>{item.location}</div>
-                    <div>{item.date}</div>
-                    <div>{item.reward}</div>
-                </PostBox>
+                <Link key={item.id} href={`/items/${item.id}`}>
+                    <PostBox>
+                        <div>{item.ongoing ? '진행 중' : null}</div>
+                        <div>{item.title}</div>
+                        <div>{item.location}</div>
+                        <div>{item.date}</div>
+                        <div>{item.reward}</div>
+                    </PostBox>
+                </Link>
             ))}
         </>
     );

--- a/components/Request/index.tsx
+++ b/components/Request/index.tsx
@@ -1,15 +1,10 @@
 import styled from '@emotion/styled';
 import { dbService } from 'fbase';
 import { addDoc, collection, serverTimestamp } from 'firebase/firestore';
-import React, { useState } from 'react';
+import React from 'react';
 import { useDispatch } from 'react-redux';
 import { useSelector } from 'react-redux';
-import {
-    ItemTypes,
-    requestAction,
-    requestInitialState,
-    RootState,
-} from 'store';
+import { requestAction, requestInitialState, RootState } from 'store';
 import RequestDetail from './RequestDetail';
 import RequestLocation from './RequestLocation';
 import RequestReward from './RequestReward';
@@ -32,7 +27,7 @@ const Request = (props: Props) => {
                 date: serverTimestamp(),
             });
             dispatch(requestAction.request(requestInitialState.request));
-            router.push('/');
+            router.push(`/items/${docRef.id}`);
         } else return;
     };
 

--- a/pages/items/[id].tsx
+++ b/pages/items/[id].tsx
@@ -1,9 +1,43 @@
-import React from 'react';
+import Item from 'components/Item';
+import { dbService } from 'fbase';
+import {
+    collection,
+    DocumentData,
+    getDocs,
+    QueryDocumentSnapshot,
+} from 'firebase/firestore';
+import { useRouter } from 'next/router';
+import React, { useEffect, useState } from 'react';
+import { ItemTypes } from 'store';
 
 type Props = {};
 
 const ItemPage = ({}: Props) => {
-    return <div>Items</div>;
+    const router = useRouter();
+    const { id } = router.query;
+    const [item, setItem] = useState<ItemTypes>();
+    useEffect(() => {
+        if (id) {
+            const fetchDoc = async () => {
+                const querySnapshot = await getDocs(
+                    collection(dbService, 'items'),
+                );
+                const findDoc = querySnapshot.docs.find(
+                    (doc: QueryDocumentSnapshot<DocumentData>) => doc.id === id,
+                );
+                const docItem = {
+                    ...findDoc?.data(),
+                    id: findDoc?.id,
+                    date: findDoc?.data().date?.toDate().getTime(),
+                };
+                setItem(docItem);
+            };
+            fetchDoc();
+            return;
+        }
+    }, [id]);
+
+    return item && <Item item={item} />;
 };
 
 export default ItemPage;

--- a/store/index.ts
+++ b/store/index.ts
@@ -2,14 +2,14 @@ import { combineReducers, configureStore, createSlice } from '@reduxjs/toolkit';
 import { createWrapper } from 'next-redux-wrapper';
 
 export interface ItemTypes {
-    title: string;
-    date: string;
-    location: string;
-    reward: number | string;
-    ongoing: boolean;
+    title?: string;
+    date?: string;
+    location?: string;
+    reward?: number | string;
+    ongoing?: boolean;
     contents?: string;
     userId?: string;
-    id?: string;
+    id?: string | undefined;
 }
 interface ItemListTypes {
     itemList: ItemTypes[];
@@ -23,7 +23,7 @@ const itemListSlice = createSlice({
     name: 'itemlist',
     initialState: itemListInitialState,
     reducers: {
-        itemList(state, action) {
+        load(state, action) {
             state.itemList = action.payload;
         },
     },
@@ -51,9 +51,6 @@ const requestSlice = createSlice({
     reducers: {
         request(state, action) {
             state.request = action.payload;
-        },
-        init(state, action) {
-            state.request = requestInitialState.request;
         },
     },
 });


### PR DESCRIPTION
잡행 요청 페이지 

잡행 요청글 작성 시 => 잡행 요청 페이지로 이동하는 동시에 firestore db에서 url params와 id가 같은 데이터를 찾은 후 state에 담아 item 컴포넌트에 props로 전달